### PR TITLE
Update enrichment_in_groups.R

### DIFF
--- a/R/enrichment_in_groups.R
+++ b/R/enrichment_in_groups.R
@@ -90,8 +90,11 @@ enrichment_in_groups <- function(geneset, targets=NULL, background=NULL, method=
         #foldx = mean(in_group, na.rm=T)/mean(background, na.rm=T)
         
         # rank from largest to smallest
-        if (is.null(mapping_column)) in_rank = rank(backlist)[which(rownames(background) %in% grouplist)]
-        else in_rank = rank(backlist)[which(background[,mapping_column] %in% grouplist)]
+        # NOTE: By default, the function 'rank' outputs the position in the list from smallest to largest.
+        # that is, rank(backlist) has the most negative values at the top, with the most positive at the bottom.
+        # To get the positive entries at the top, negative at the bottom, we use rank(-backlist) instead.
+        if (is.null(mapping_column)) in_rank = rank(-backlist)[which(rownames(background) %in% grouplist)]
+        else in_rank = rank(-backlist)[which(background[,mapping_column] %in% grouplist)]
         
         # this will give not a fold enrichment - but a score that ranges from 1 (most in top)
         #      to -1 (most in bottom).


### PR DESCRIPTION
Fixing a typo with the oddsratio statistic within enrichment_in_groups.

The function 'rank' places the most negative values at the top of the list (rank of 1), and most positive values at the bottom of the list. For this reason, oddsratio and zscore were negatively correlated, since a positive zscore would correspond to being near the bottom of the ranks, giving a negative oddsratio.

I changed the ranking to be rank(-backlist), so that we get the most positive values at the top (rank 1), and the most negative at the bottom. Now oddsratio and zscore agree, a large zscore means large oddsratio, and vice versa.