### PR TITLE
Fix enrichment in groups sohi

### DIFF
--- a/R/enrichment_in_groups.R
+++ b/R/enrichment_in_groups.R
@@ -96,8 +96,8 @@ enrichment_in_groups <- function(geneset, targets=NULL, background=NULL, method=
             print(e)
           },
           warning=function(w) {
-            message('A Warning Occurred')
-            print(w)
+            #message('A Warning Occurred') # No need to print this out for the user.
+            #print(w) # No need to print this out for the user.
             return(enr)
           }
         )

--- a/R/enrichment_in_groups.R
+++ b/R/enrichment_in_groups.R
@@ -74,15 +74,34 @@ enrichment_in_groups <- function(geneset, targets=NULL, background=NULL, method=
       if (in_path > minsize) {
         in_back = length(backlist)
         
-        enr = try(ks.test(in_group, backlist), silent=silence_try_errors)
-        if (class(enr) == "try-error") {
-          enr = NA
-          p.value = NA
-          #browser()
-        }
-        else {
-          p.value = enr$p.value
-        }
+        # enr = try(ks.test(in_group, backlist), silent=silence_try_errors)
+        # if (class(enr) == "try-error") {
+        #   enr = NA
+        #   p.value = NA
+        #   #browser()
+        # }
+        # else {
+        #   p.value = enr$p.value
+        # }
+        # The above block of code was replaced by the tryCatch block below to handle errors and warnings more elegantly.
+        # The if(class(enr)) statement causes an error which doesn't let the rest of the code run.
+        # Proposed change by Harkirat Sohi:
+        tryCatch(
+          {
+            enr = ks.test(in_group, backlist)
+            return(enr)
+          },
+          error=function(e) {
+            message('An Error Occurred')
+            print(e)
+          },
+          warning=function(w) {
+            message('A Warning Occurred')
+            print(w)
+            return(enr)
+          }
+        )
+        p.value = enr$p.value
         
         # this expression of foldx might be subject to some weird pathological conditions
         # e.g. one sample has a background that is always negative, another that's positive


### PR DESCRIPTION
Made 2 commits ; notes are below.

#########################
Commit 1:
Big picture: Edited code so that method = enrichment_in_order option in leapR works without breaking down.
Changes proposed to fix the following error from running enrichment_in_groups.R
Below is a brief description of the error, what is causing it and a proposed solution/fix.

Error
Error in if (class(enr) == "try-error") { : the condition has length > 1

Debugging (Problem identified)
See lines 77 and 78 in enrichment_in_groups.R (master branch as of March 1, 2023)
The error occurs beause length(class(enr)) is not 1, so the if statement doesn't get executed.
class(enr)
[1] "ks.test" "htest"
Besides, to follow good practice, it is best not to have a test on class(enr) in order to catch errors.

Proposed fix:
Replaced the if statement block of code with a tryCatch statement to handle potential errors and warnings more elegantly.
#############################

#############################
Commit 2:
Removed printing of Warning messages from the added tryCatch statement in the previous commit. The warning message is not particularly useful for users.

<simpleWarning in ks.test.default(in_group, backlist): p-value will be approximate in the presence of ties>
############################
